### PR TITLE
Recursive VCS subpath search

### DIFF
--- a/src/bzr.cpp
+++ b/src/bzr.cpp
@@ -26,7 +26,7 @@ std::string gGourceBzrLogCommand() {
     return std::string("bzr log --verbose -r 1..-1 --short -n0 --forward");
 }
 
-BazaarLog::BazaarLog(const std::string& logfile) : RCommitLog(logfile) {
+BazaarLog::BazaarLog(const std::string& logfile) : RCommitLog(logfile, ".bzr") {
 
     log_command = gGourceBzrLogCommand();
 

--- a/src/commitlog.h
+++ b/src/commitlog.h
@@ -81,8 +81,10 @@ protected:
     bool getNextLine(std::string& line);
 
     virtual bool parseCommit(RCommit& commit) { return false; };
+
+    const std::string logfile;
 public:
-    RCommitLog(const std::string& logfile, int firstChar = -1);
+    RCommitLog(const std::string& logfile, const std::string& vcssub = "", int firstChar = -1);
     ~RCommitLog();
 
     void seekTo(float percent);
@@ -97,6 +99,8 @@ public:
     bool isFinished();
     bool isSeekable();
     float getPercent();
+
+    static const std::string findRepositoryRoot(const std::string& prjdir, const std::string& vcssub);
 };
 
 #endif

--- a/src/cvs2cl.cpp
+++ b/src/cvs2cl.cpp
@@ -24,7 +24,7 @@ Regex cvs2cl_logentry_timestamp("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\
 
 std::string gGourceCVS2CLLogCommand = "cvs2cl --chrono --stdout --xml -g-q";
 
-CVS2CLCommitLog::CVS2CLCommitLog(const std::string& logfile) : RCommitLog(logfile, '<') {
+CVS2CLCommitLog::CVS2CLCommitLog(const std::string& logfile) : RCommitLog(logfile, "", '<') {
 }
 
 bool CVS2CLCommitLog::parseCommit(RCommit& commit) {

--- a/src/git.cpp
+++ b/src/git.cpp
@@ -29,7 +29,7 @@ std::string gGourceGitLogCommand = "git log "
     "--reverse --raw --encoding=UTF-8 "
     "--no-renames";
 
-GitCommitLog::GitCommitLog(const std::string& logfile) : RCommitLog(logfile, 'u') {
+GitCommitLog::GitCommitLog(const std::string& logfile) : RCommitLog(logfile, ".git", 'u') {
 
     log_command = gGourceGitLogCommand;
 
@@ -40,7 +40,7 @@ GitCommitLog::GitCommitLog(const std::string& logfile) : RCommitLog(logfile, 'u'
 
     //can generate log from directory
     if(!logf && is_dir) {
-        logf = generateLog(logfile);
+        logf = generateLog(this->logfile);
 
         if(logf) {
             success  = true;
@@ -163,34 +163,5 @@ bool GitCommitLog::parseCommit(RCommit& commit) {
     if(commit.username.size()==0) return false;
 
     return true;
-}
-
-const std::string GitCommitLog::searchGitDirectory( const std::string& actualdir )
-{
-        struct stat st;
-
-        std::string d = actualdir;
-
-        while( true )
-        {
-                std::string s = d + "/.git";
-
-                if( 0 == stat( s.c_str(), &st ) )
-                {
-                        return d;
-                }
-                if( 0 != stat( d.c_str(), &st ) )
-                {
-                        return actualdir;
-                }
-
-                d = std::string( "../" ) + d;
-
-                // just to be sure :/
-                if( d.length() > 1024 )
-                        return actualdir;
-        }
-
-        return actualdir;
 }
 

--- a/src/git.h
+++ b/src/git.h
@@ -32,8 +32,6 @@ protected:
     BaseLog* generateLog(const std::string& dir);
 public:
     GitCommitLog(const std::string& logfile);
-
-    static const std::string searchGitDirectory( const std::string& actualdir );
 };
 
 #endif

--- a/src/gitraw.cpp
+++ b/src/gitraw.cpp
@@ -28,7 +28,7 @@ Regex git_raw_file("^:[0-9]+ [0-9]+ [0-9a-z]+\\.* ([0-9a-z]+)\\.* ([A-Z])[ \\t]+
 
 std::string gGourceGitRawLogCommand = "git log --reverse --raw --pretty=raw";
 
-GitRawCommitLog::GitRawCommitLog(const std::string& logfile) : RCommitLog(logfile, 'c') {
+GitRawCommitLog::GitRawCommitLog(const std::string& logfile) : RCommitLog(logfile, "", 'c') {
 
     log_command = gGourceGitRawLogCommand;
 }

--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -244,7 +244,7 @@ RCommitLog* Gource::determineFormat(const std::string& logfile) {
 
     //git
     debugLog("trying git...\n");
-    clog = new GitCommitLog( GitCommitLog::searchGitDirectory( logfile ));
+    clog = new GitCommitLog( logfile );
     if(clog->checkFormat()) return clog;
 
     delete clog;

--- a/src/hg.cpp
+++ b/src/hg.cpp
@@ -28,7 +28,7 @@ std::string gGourceMercurialCommand() {
     return std::string("hg log -r 0:tip --style \"") + gource_style_path + std::string("\"");
 }
 
-MercurialLog::MercurialLog(const std::string& logfile) : RCommitLog(logfile) {
+MercurialLog::MercurialLog(const std::string& logfile) : RCommitLog(logfile, ".hg") {
 
     log_command = gGourceMercurialCommand();
 

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -24,7 +24,7 @@ Regex svn_logentry_timestamp("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{
 
 std::string gGourceSVNLogCommand = "svn log -r 1:HEAD --xml --verbose --quiet";
 
-SVNCommitLog::SVNCommitLog(const std::string& logfile) : RCommitLog(logfile, '<') {
+SVNCommitLog::SVNCommitLog(const std::string& logfile) : RCommitLog(logfile, ".svn", '<') {
 
     log_command = gGourceSVNLogCommand;
 


### PR DESCRIPTION
Introduced common recursive search. Tested for git: works in a git root directory, in a git subdirectory and does not find a path (and does not crash) out of a git directory. testing and codereview for the other vcs systems required.
