### PR TITLE
Quick fix for boost 1.50

### DIFF
--- a/src/logmill.cpp
+++ b/src/logmill.cpp
@@ -176,7 +176,7 @@ RCommitLog* RLogMill::fetchLog(std::string& log_format) {
                     logfile = repo_path.string();
                 }
             }
-        } catch(boost::filesystem3::filesystem_error& error) {
+        } catch(boost::filesystem::filesystem_error& error) {
         }
     }
 


### PR DESCRIPTION
This simply changes the namespace name for "filesystem" since boost 1.50 removed filesystem v2 entirely.
