### PR TITLE
Use author date, not commit date, for Git commits

### DIFF
--- a/src/formats/git.cpp
+++ b/src/formats/git.cpp
@@ -25,7 +25,7 @@
 //   and try a different format (eg cvs-exp)
 
 std::string gGourceGitLogCommand = "git log "
-    "--pretty=format:user:%aN%n%ct "
+    "--pretty=format:user:%aN%n%at "
     "--reverse --raw --encoding=UTF-8 "
     "--no-renames";
 


### PR DESCRIPTION
Git author and committer can be different, and so can author and commit dates (i.e. someone might have re-committed earlier changes to a new repository, or imported them from another VCS). So Gource should show author date (it already shows the author name and not the committer name).
