### PR TITLE
Change file colour on modification (issue 161) 

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -161,6 +161,10 @@ const vec3& RFile::getNameColour() const{
     return selected ? gGourceSettings.selection_colour : namecol;
 }
 
+void RFile::setFileColour(const vec3 & colour) {
+    file_colour = colour;
+}
+
 const vec3 & RFile::getFileColour() const{
     return file_colour;
 }

--- a/src/file.h
+++ b/src/file.h
@@ -61,6 +61,7 @@ public:
 
     bool overlaps(const vec2& pos) const;
 
+    void setFileColour(const vec3 & colour);
     const vec3 & getFileColour() const;
     vec3 getColour() const;
     void colourize();

--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1120,6 +1120,11 @@ void Gource::processCommit(RCommit& commit, float t) {
 
             if(!file) continue;
         }
+        else {
+            if (cf.action == "M") {
+                file->setFileColour(cf.colour);
+            }
+        }
 
         addFileAction(commit.username, cf.action, file, t);
     }


### PR DESCRIPTION
A custom log allows a file colour to be set on modification, however Gource doesn't change the colour from its original value.  This is the situation described in issue 161: https://code.google.com/p/gource/issues/detail?id=161
