### PR TITLE
First step to instant display new changes of a local git repository in Gource

### DIFF
--- a/scripts/gource-git-live-init.sh
+++ b/scripts/gource-git-live-init.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This script initializes the Gource in "gource-git-live" mode.
+# In result, Gource will wait for you to use "gource-git-refresh.sh" script,
+# which will update the log and the current graph view.
+# @author: Konrad Talik (github.com/ktalik)
+
+# usage:
+#    gource-git-live-init.sh
+
+mkfifo .gourcefifo
+
+# Transfer .gourcefifo to the STDIN.of Gource.
+`gource --realtime --log-format git - < .gourcefifo`
+
+rm .gourcefifo
+

--- a/scripts/gource-git-refresh.sh
+++ b/scripts/gource-git-refresh.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script updates Gource, when in "gource-git-live" mode.
+# @author: Konrad Talik (github.com/ktalik)
+
+# usage:
+#    gource-git-refresh.sh
+
+# NOTE: You should run it after every commit or in an alias.
+
+# Send the last line of the log to the .gourcefifo.
+git log -1 --pretty=format:user:%aN%n%ct --reverse --raw --encoding=UTF-8 --no-renames > .gourcefifo


### PR DESCRIPTION
Greetings. I made a simple script (or to be precise - two short bash commands) that handle a display of new changes of a local git repository. It is possible to upgrade it to deal with remaining version control systems. You must only know how "log-command" options are working and change them to display only recent changes. Scripts are in bash and are using temporary fifo file, so I'm not sure if it will work on other systems than Unix :thought_balloon: 

I suggest making a new option in the Gource itself or simply make this bash script available to run like a system command. In my humble opinion, both of those ways will provide users much convenience.

Regards,
Konrad Talik
