### PR TITLE
author instantiation may crash if GetText() returns NULL

### DIFF
--- a/src/formats/svn.cpp
+++ b/src/formats/svn.cpp
@@ -245,8 +245,8 @@ bool SVNCommitLog::parseCommit(RCommit& commit) {
     TiXmlElement* authorE = leE->FirstChildElement("author");
 
     if(authorE != 0) {
-
-        std::string author(authorE->GetText());
+		// GetText() may return NULL, causing author instantiation to crash.
+        std::string author(authorE->GetText() ? authorE->GetText() : "Unknown");
 
         if(author.empty()) author = "Unknown";
 


### PR DESCRIPTION
Gource will crash/dump core (tested on Windows, Linux and Mac OS X) if authorE->GetText() returns NULL.

This occured consistently with data generated from an SVN dump which was converted from a CVS repository, which in turn was originally converted from RCS files, some of which were 30 years old. Author information for check-ins was not always available, causing the commit user names to be invalid.

This is a quick fix at best.