### PR TITLE
Allow configuration of filename text colour and display time

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -32,7 +32,7 @@ RFile::RFile(const std::string & name, const vec3 & colour, const vec2 & pos, in
     setGraphic(gGourceSettings.file_graphic);
 
     speed = 5.0;
-    nametime = 4.0;
+    nametime = gGourceSettings.filename_time;
     name_interval = nametime;
 
     namecol     = vec3(1.0, 1.0, 1.0);
@@ -60,7 +60,7 @@ RFile::RFile(const std::string & name, const vec3 & colour, const vec2 & pos, in
         file_font = fontmanager.grab("FreeSans.ttf", 14);
         file_font.dropShadow(true);
         file_font.roundCoordinates(false);
-        file_font.setColour(vec4(1.0f, 1.0f, 1.0f, 1.0f));
+        file_font.setColour(vec4(gGourceSettings.filename_colour, 1.0f));
     }
 
     //namelist = glGenLists(1);

--- a/src/file.h
+++ b/src/file.h
@@ -27,6 +27,7 @@ class RDirNode;
 class RFile : public Pawn {
     vec3 file_colour;
     vec3 touch_colour;
+    vec3 name_colour;
 
     RDirNode* dir;
 

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -150,6 +150,10 @@ if(extended_help) {
     printf("  --caption-duration SECONDS  Caption duration (default: 10.0)\n");
     printf("  --caption-offset X          Caption horizontal offset\n\n");
 
+    printf("  --filename-colour FFFFFF  Font colour for filenames\n");
+    printf("  --filename-time SECONDS   Duration to keep filenames on screen (4.0)\n");
+    printf("                            Must be >= 2.0 seconds\n\n");
+
     printf("  --hash-seed SEED         Change the seed of hash function.\n\n");
 
     printf("  --path PATH\n\n");
@@ -309,6 +313,9 @@ GourceSettings::GourceSettings() {
     arg_types["caption-colour"]     = "string";
     arg_types["caption-offset"]     = "int";
 
+    arg_types["filename-colour"]    = "string";
+    arg_types["filename-time"] = "float";
+
     arg_types["dir-name-depth"]     = "int";
 }
 
@@ -414,6 +421,9 @@ void GourceSettings::setGourceDefaults() {
     caption_size     = 16;
     caption_offset   = 0;
     caption_colour   = vec3(1.0f, 1.0f, 1.0f);
+
+    filename_colour  = vec3(1.0f, 1.0f, 1.0f);
+    filename_time = 4.0f;
 
     gStringHashSeed = 31;
 
@@ -803,6 +813,34 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
             caption_colour = vec3(r,g,b);
             caption_colour /= 255.0f;
         } else {
+            conffile.invalidValueException(entry);
+        }
+    }
+
+    if((entry = gource_settings->getEntry("filename-colour")) != 0) {
+        if(!entry->hasValue()) conffile.entryException(entry, "specify filename colour (FFFFFF)");
+
+	int r,g,b;
+
+	std::string colstring = entry->getString();
+
+	if(entry->isVec3()) {
+	    filename_colour = entry->getVec3();
+	} else if(colstring.size()==6 && sscanf(colstring.c_str(), "%02x%02x%02x", &r, &g, &b) == 3) {
+            filename_colour = vec3(r,g,b);
+            filename_colour /= 255.0f;
+        } else {
+            conffile.invalidValueException(entry);
+        }
+    }
+
+    if((entry = gource_settings->getEntry("filename-time")) != 0) {
+
+        if(!entry->hasValue()) conffile.entryException(entry, "specify duration to keep files on screen (float, >= 2.0)");
+
+        filename_time = entry->getFloat();
+
+        if(filename_time<2.0f) {
             conffile.invalidValueException(entry);
         }
     }

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -139,6 +139,9 @@ public:
     int caption_size;
     int caption_offset;
 
+    vec3 filename_colour;
+    float filename_time;
+
     std::string output_custom_filename;
 
     TextureResource* file_graphic;


### PR DESCRIPTION
I found my filenames didn't look very good on a white background. I also wanted to show them on-screen for a shorter period of time, so that they didn't all overwrite each other so much.
