### PR TITLE
Issue #46 Implement file-show-filter

### DIFF
--- a/src/formats/commitlog.cpp
+++ b/src/formats/commitlog.cpp
@@ -328,6 +328,18 @@ void RCommit::addFile(const std::string& filename, const  std::string& action, c
         }
     }
 
+    // Only allow files that have been whitelisted
+    if(!gGourceSettings.file_show_filters.empty()) {
+
+        for(std::vector<Regex*>::iterator ri = gGourceSettings.file_show_filters.begin(); ri != gGourceSettings.file_show_filters.end(); ri++) {
+            Regex* r = *ri;
+
+            if(!r->match(filename)) {
+                return;
+            }
+        }
+    }
+
     files.push_back(RCommitFile(filename, action, colour));
 }
 

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -128,6 +128,7 @@ if(extended_help) {
 
     printf("  --user-filter REGEX      Ignore usernames matching this regex\n");
     printf("  --file-filter REGEX      Ignore files matching this regex\n\n");
+    printf("  --file-show-filter REGEX Show files matching this regex\n\n");
 
     printf("  --user-friction SECONDS  Change the rate users slow down (default: 0.67)\n");
     printf("  --user-scale SCALE       Change scale of users (default: 1.0)\n");
@@ -268,6 +269,7 @@ GourceSettings::GourceSettings() {
 
     arg_types["user-filter"]    = "multi-value";
     arg_types["file-filter"]    = "multi-value";
+    arg_types["file-show-filter"]    = "multi-value";
     arg_types["follow-user"]    = "multi-value";
     arg_types["highlight-user"] = "multi-value";
 
@@ -422,6 +424,13 @@ void GourceSettings::setGourceDefaults() {
         delete (*it);
     }
     file_filters.clear();
+
+    //delete file whitelists
+    for(std::vector<Regex*>::iterator it = file_show_filters.begin(); it != file_show_filters.end(); it++) {
+        delete (*it);
+    }
+    file_show_filters.clear();
+
     file_extensions = false;
 
     //delete user filters
@@ -1295,6 +1304,29 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
             }
 
             file_filters.push_back(r);
+        }
+    }
+
+    if((entry = gource_settings->getEntry("file-show-filter")) != 0) {
+
+        ConfEntryList* filters = gource_settings->getEntries("file-show-filter");
+
+        for(ConfEntryList::iterator it = filters->begin(); it != filters->end(); it++) {
+
+            entry = *it;
+
+            if(!entry->hasValue()) conffile.entryException(entry, "specify file-filter (regex)");
+
+            std::string filter_string = entry->getString();
+
+            Regex* r = new Regex(filter_string, 1);
+
+            if(!r->isValid()) {
+                delete r;
+                conffile.entryException(entry, "invalid file-filter regular expression");
+            }
+
+            file_show_filters.push_back(r);
         }
     }
 

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -130,6 +130,7 @@ public:
     std::vector<std::string> highlight_users;
     std::vector<std::string> follow_users;
     std::vector<Regex*> file_filters;
+    std::vector<Regex*> file_show_filters;
     std::vector<Regex*> user_filters;
     bool file_extensions;
 

--- a/tests/test.conf
+++ b/tests/test.conf
@@ -20,6 +20,12 @@ file-filter=\.cpp
 stop-at-time=5.0
 
 [gource]
+title=Filename filter (.cpp)
+file-show-filter=\.cpp
+stop-at-time=5.0
+
+
+[gource]
 title=Directory delete (SVN)
 path=logs/svn-dir-delete.log
 stop-at-time=5.0


### PR DESCRIPTION
I haven't touched the original file-filter option in this commit. The original poster mentioned doing this so that the names would be more obvious inverses of each other, but I went with the minimal changes, since there was no confirmed interest in deprecating the original "file-filter" name.

I'm rusty on my cpp, so I'm not sure how you go about executing the tests for this project. I added a test case that I think will cover this change, but I'd like to run them and know for sure.