### PR TITLE
Fix very low seconds-per-day

### DIFF
--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1711,7 +1711,7 @@ void Gource::logic(float t, float dt) {
 
         processCommit(commit, t);
 
-        currtime = lasttime = commit.timestamp;
+        lasttime = commit.timestamp;
         subseconds = 0.0;
 
         commitqueue.pop_front();


### PR DESCRIPTION
Hi,

This pull request fixes https://github.com/acaudwell/Gource/issues/96

Not sure why currtime was set here, but it caused it to go back in time when seconds-per-day is very low.

The real issue might be related to a default commitqueue_max_size too low, but raising it didn't fix the bug.