### PR TITLE
formats: allow a-f in custom log colour codes

### DIFF
--- a/src/formats/custom.cpp
+++ b/src/formats/custom.cpp
@@ -17,7 +17,7 @@
 
 #include "custom.h"
 
-Regex custom_regex("^(?:\\xEF\\xBB\\xBF)?(-?[0-9]+)\\|([^|]*)\\|([ADM]?)\\|([^|]+)(?:\\|#?([A-F0-9]{6}))?");
+Regex custom_regex("^(?:\\xEF\\xBB\\xBF)?(-?[0-9]+)\\|([^|]*)\\|([ADM]?)\\|([^|]+)(?:\\|#?([a-fA-F0-9]{6}))?");
 
 CustomLog::CustomLog(const std::string& logfile) : RCommitLog(logfile) {
 }


### PR DESCRIPTION
When using the w3 schools color picker the generated colour code contains lower case hex chars. This update will allow for direct copy and paste.