### PR TITLE
Some new options to distinguish date and title, +American spelling of color

### DIFF
--- a/README
+++ b/README
@@ -110,7 +110,7 @@ options:
     -e, --elasticity FLOAT
             Elasticity of nodes.
 
-    -b, --background-colour FFFFFF
+    -b, --background, --background-colour, --background-color FFFFFF
             Background colour in hex.
 
     --background-image IMAGE
@@ -128,8 +128,20 @@ options:
     --font-size SIZE
             Font size used by the date and title.
 
-    --font-colour FFFFFF
+    --title-size SIZE
+            Font size used by just the title.
+
+    --font-colour, --font-color FFFFFF
             Font colour used by the date and title in hex.
+
+    --title-colour, --title-color FFFFFF
+            Font colour used by just the title in hex.
+
+    --date-height-pad VALUE
+            Value to add to the y position of the date.
+
+    --title-height-pad VALUE
+            Value to add to the y position of the title.
 
     --key
             Show file extension key.
@@ -160,16 +172,16 @@ options:
     --highlight-users
             Highlight the names of all users.
 
-    --highlight-colour FFFFFF
+    --highlight-colour, --highlight-color FFFFFF
             Font colour for highlighted users in hex.
 
-    --selection-colour FFFFFF
+    --selection-colour, --selection-color FFFFFF
             Font colour for selected users and files.
 
-    --filename-colour FFFFFF
+    --filename-colour, --filename-color FFFFFF
             Font colour for filenames.
 
-    --dir-colour FFFFFF
+    --dir-colour, --dir-color FFFFFF
             Font colour for directories.
 
     --dir-name-depth DEPTH
@@ -197,7 +209,7 @@ options:
     --default-user-image IMAGE
             Path of .jpg or .png to use as the default user image.
 
-    --colour-images
+    --colour-images, --color-images
             Colourize user images.
 
     --crop AXIS
@@ -269,7 +281,7 @@ options:
     --caption-size SIZE
             Caption size.
 
-    --caption-colour FFFFFF
+    --caption-colour, --caption-color FFFFFF
             Caption colour in hex.
 
     --caption-duration SECONDS

--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -44,6 +44,19 @@ Gource::Gource(FrameExporter* exporter) {
     fontmedium.dropShadow(true);
     fontmedium.roundCoordinates(false);
 
+    int title_size = (gGourceSettings.title_font_size>0?gGourceSettings.title_font_size:gGourceSettings.font_size);
+    fonttitle = fontmanager.grab("FreeSans.ttf", title_size);
+    fonttitle.dropShadow(true);
+    fonttitle.roundCoordinates(false);
+    fonttitle.alignTop(false);
+
+    // Fall back to generic font color if title font color was not set
+    if(gGourceSettings.title_font_colour.x < 0) {
+        gGourceSettings.title_font_colour = gGourceSettings.font_colour;
+    }
+
+    title_x_offset = (int) fonttitle.getWidth(gGourceSettings.title) * 0.5;
+
     fontcaption = fontmanager.grab("FreeSans.ttf", gGourceSettings.caption_size);
     fontcaption.dropShadow(true);
     fontcaption.roundCoordinates(false);
@@ -2591,13 +2604,29 @@ void Gource::draw(float t, float dt) {
     fontmedium.setColour(vec4(gGourceSettings.font_colour, 1.0f));
 
     if(!gGourceSettings.hide_date) {
-        fontmedium.draw(display.width/2 - date_x_offset, 20, displaydate);
+        int x, y;
+        if(gGourceSettings.swap_title_and_date) {
+            x = 10;
+            y = display.height + fontmedium.getDescender() - 10 - gGourceSettings.date_height_pad;
+        } else {
+            x = display.width/2 - date_x_offset;
+            y = fontmedium.getAscender() + 10 + gGourceSettings.date_height_pad;
+        }
+        fontmedium.draw(x, y, displaydate);
     }
 
+    fonttitle.setColour(vec4(gGourceSettings.title_font_colour, 1.0f));
+
     if(!gGourceSettings.title.empty()) {
-        fontmedium.alignTop(false);
-        fontmedium.draw(10, display.height - 10, gGourceSettings.title);
-        fontmedium.alignTop(true);
+        int x, y;
+        if(gGourceSettings.swap_title_and_date) {
+            x = display.width/2 - title_x_offset;
+            y = fonttitle.getAscender() + 10 + gGourceSettings.title_height_pad;
+        } else {
+            x = 10;
+            y = display.height + fonttitle.getDescender() - 10 - gGourceSettings.title_height_pad;
+        }
+        fonttitle.draw(x, y, gGourceSettings.title);
     }
 
     for(std::list<RCaption*>::iterator it = active_captions.begin(); it!=active_captions.end(); it++) {

--- a/src/gource.h
+++ b/src/gource.h
@@ -117,6 +117,7 @@ class Gource : public SDLApp {
 
     std::string displaydate;
     int date_x_offset;
+    int title_x_offset;
 
     TextureResource* bloomtex;
     TextureResource* beamtex;
@@ -132,7 +133,7 @@ class Gource : public SDLApp {
 
     TextBox textbox;
 
-    FXFont font, fontlarge, fontmedium, fontcaption;
+    FXFont font, fontlarge, fontmedium, fonttitle, fontcaption;
 
     bool first_read;
     bool paused;

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -214,6 +214,17 @@ GourceSettings::GourceSettings() {
     arg_aliases["disable-progress"]    = "hide-progress";
     arg_aliases["highlight-all-users"] = "highlight-users";
 
+    //american spelling of colour (color)
+    arg_aliases["color-images"]      = "colour-images";
+    arg_aliases["background-color"]  = "background-colour";
+    arg_aliases["font-color"]        = "font-colour";
+    arg_aliases["title-color"]       = "title-colour";
+    arg_aliases["highlight-color"]   = "highlight-colour";
+    arg_aliases["selection-color"]   = "selection-colour";
+    arg_aliases["dir-color"]         = "dir-colour";
+    arg_aliases["caption-color"]     = "caption-colour";
+    arg_aliases["filename-color"]    = "filename-colour";
+
     //command line only options
     conf_sections["help"]            = "command-line";
     conf_sections["extended-help"]   = "command-line";

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -102,6 +102,14 @@ public:
     int font_size;
     vec3 font_colour;
 
+    int title_font_size;
+    vec3 title_font_colour;
+
+    int date_height_pad;
+    int title_height_pad;
+
+    bool swap_title_and_date;
+
     float elasticity;
 
     std::string git_branch;
@@ -148,7 +156,7 @@ public:
     TextureResource* file_graphic;
 
     int log_level;
-    
+
     GourceSettings();
 
     void setGourceDefaults();


### PR DESCRIPTION
Added some options for myself to customize the date and title independently and to swap their positions. Also tried to get them to compute a better y position but it's still not perfect so added CL options to fudge the final value. Lastly, added some aliases for command line options using American spelling of color.