### PR TITLE
Fix command synopsis to use normal manual-page command syntax.

### DIFF
--- a/data/gource.1
+++ b/data/gource.1
@@ -3,7 +3,7 @@
 Gource - a software version control visualization
 .SH SYNOPSIS
 \fIgource\fR
-<options> <path>
+[options] path
 .SH DESCRIPTION
 \fIgource\fR is an OpenGL-based 3D visualisation tool for source control repositories.
 


### PR DESCRIPTION
This is significant for tools like doclifter that lift to XML/HTML.