### PR TITLE
Added file-extension-fallback to the configuration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 0.50:
  * Added --no-time-travel option (Lars Schmertmann).
  * Added --dir-name-position option (Lars Schmertmann).
+ * Added --file-extension-fallback option (Lars Schmertmann).
  * Fixed a bug in the log file format detection that could result in the wrong
    first entry being displayed for a custom log.
 

--- a/README
+++ b/README
@@ -194,6 +194,9 @@ options:
     --file-extensions
             Show filename extensions only.
 
+    --file-extension-fallback
+            Use filename as extension if the extension is missing or empty.
+
     --file-filter REGEX
             Filter out file paths matching the specified regular expression.
 

--- a/data/gource.1
+++ b/data/gource.1
@@ -160,6 +160,9 @@ Duration to keep filenames on screen (>= 2.0).
 \fB\-\-file\-extensions\fR
 Show filename extensions only.
 .TP
+\fB\-\-file\-extension\-fallback\fR
+Use filename as extension if the extension is missing or empty.
+.TP
 \fB\-\-file\-filter REGEX\fR
 Filter out file paths matching the specified regular expression.
 .TP

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -119,10 +119,12 @@ void RFile::setFilename(const std::string& abs_file_path) {
     }
 
     //trim name to just extension
-    int dotsep=0;
+    size_t dotsep = name.rfind(".");
 
-    if((dotsep=name.rfind(".")) != std::string::npos && dotsep != name.size()-1) {
+    if(dotsep != std::string::npos && dotsep != name.size()-1) {
         ext = name.substr(dotsep+1);
+    } else if(gGourceSettings.file_extension_fallback) {
+        ext = name;
     }
 }
 

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -119,6 +119,9 @@ if(extended_help) {
 
     printf("  --file-extensions        Show filename extensions only\n\n");
 
+    printf("  --file-extension-fallback  Use filename as extension if the\n");
+    printf("                             extension is missing or empty\n\n");
+
     printf("  --git-branch             Get the git log of a particular branch\n\n");
 
     printf("  --hide DISPLAY_ELEMENT   bloom,date,dirnames,files,filenames,mouse,progress,\n");
@@ -227,31 +230,32 @@ GourceSettings::GourceSettings() {
     conf_sections["log-level"]         = "command-line";
 
     //boolean args
-    arg_types["help"]            = "bool";
-    arg_types["extended-help"]   = "bool";
-    arg_types["stop-on-idle"]    = "bool";
-    arg_types["stop-at-end"]     = "bool";
-    arg_types["dont-stop"]       = "bool";
-    arg_types["loop"]            = "bool";
-    arg_types["realtime"]        = "bool";
-    arg_types["no-time-travel"]  = "bool";
-    arg_types["colour-images"]   = "bool";
-    arg_types["hide-date"]       = "bool";
-    arg_types["hide-files"]      = "bool";
-    arg_types["hide-users"]      = "bool";
-    arg_types["hide-tree"]       = "bool";
-    arg_types["hide-usernames"]  = "bool";
-    arg_types["hide-filenames"]  = "bool";
-    arg_types["hide-dirnames"]   = "bool";
-    arg_types["hide-progress"]   = "bool";
-    arg_types["hide-bloom"]      = "bool";
-    arg_types["hide-mouse"]      = "bool";
-    arg_types["hide-root"]       = "bool";
-    arg_types["highlight-users"] = "bool";
-    arg_types["highlight-dirs"]  = "bool";
-    arg_types["file-extensions"] = "bool";
-    arg_types["key"]             = "bool";
-    arg_types["ffp"]             = "bool";
+    arg_types["help"]                    = "bool";
+    arg_types["extended-help"]           = "bool";
+    arg_types["stop-on-idle"]            = "bool";
+    arg_types["stop-at-end"]             = "bool";
+    arg_types["dont-stop"]               = "bool";
+    arg_types["loop"]                    = "bool";
+    arg_types["realtime"]                = "bool";
+    arg_types["no-time-travel"]          = "bool";
+    arg_types["colour-images"]           = "bool";
+    arg_types["hide-date"]               = "bool";
+    arg_types["hide-files"]              = "bool";
+    arg_types["hide-users"]              = "bool";
+    arg_types["hide-tree"]               = "bool";
+    arg_types["hide-usernames"]          = "bool";
+    arg_types["hide-filenames"]          = "bool";
+    arg_types["hide-dirnames"]           = "bool";
+    arg_types["hide-progress"]           = "bool";
+    arg_types["hide-bloom"]              = "bool";
+    arg_types["hide-mouse"]              = "bool";
+    arg_types["hide-root"]               = "bool";
+    arg_types["highlight-users"]         = "bool";
+    arg_types["highlight-dirs"]          = "bool";
+    arg_types["file-extensions"]         = "bool";
+    arg_types["file-extension-fallback"] = "bool";
+    arg_types["key"]                     = "bool";
+    arg_types["ffp"]                     = "bool";
 
     arg_types["disable-auto-rotate"] = "bool";
     arg_types["disable-auto-skip"]   = "bool";
@@ -453,6 +457,7 @@ void GourceSettings::setGourceDefaults() {
     file_show_filters.clear();
 
     file_extensions = false;
+    file_extension_fallback = false;
 
     //delete user filters
     for(std::vector<Regex*>::iterator it = user_filters.begin(); it != user_filters.end(); it++) {
@@ -1339,6 +1344,10 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
 
     if(gource_settings->getBool("file-extensions")) {
         file_extensions=true;
+    }
+
+    if(gource_settings->getBool("file-extension-fallback")) {
+        file_extension_fallback=true;
     }
 
     if((entry = gource_settings->getEntry("file-filter")) != 0) {

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -135,6 +135,7 @@ public:
     std::vector<Regex*> file_show_filters;
     std::vector<Regex*> user_filters;
     bool file_extensions;
+    bool file_extension_fallback;
 
     std::string caption_file;
     vec3 caption_colour;


### PR DESCRIPTION
Enabling this option causes gource to use the filename
as the file extension if no extension is set or the
filename ends with a dot. As a result every file without
an extension has an own entry in the file extension key.

#168 