### PR TITLE
Added no-time-travel to the configuration

### DIFF
--- a/README
+++ b/README
@@ -106,6 +106,9 @@ options:
         --realtime
             Realtime playback speed.
 
+        --no-time-travel
+            Use the time of the parent commit, if the time of a commit is in the past.
+
     -c, --time-scale SCALE
             Change simulation time scale.
 

--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1120,6 +1120,13 @@ void Gource::readLog() {
             break;
         }
 
+        if(gGourceSettings.no_time_travel) {
+            time_t checkTime = commitqueue.empty() ? currtime : commitqueue.back().timestamp;
+            if(commit.timestamp < checkTime) {
+                commit.timestamp = checkTime;
+            }
+        }
+
         commitqueue.push_back(commit);
     }
 

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -70,6 +70,8 @@ void GourceSettings::help(bool extended_help) {
     printf("      --disable-auto-skip          Disable auto skip\n");
     printf("  -s, --seconds-per-day SECONDS    Speed in seconds per day (default: 10)\n");
     printf("      --realtime                   Realtime playback speed\n");
+    printf("      --no-time-travel             Use the time of the parent commit,\n");
+    printf("                                   if the time of a commit is in the past.\n");
     printf("  -c, --time-scale SCALE           Change simulation time scale (default: 1.0)\n");
     printf("  -e, --elasticity FLOAT           Elasticity of nodes (default: 0.0)\n\n");
 
@@ -230,6 +232,7 @@ GourceSettings::GourceSettings() {
     arg_types["dont-stop"]       = "bool";
     arg_types["loop"]            = "bool";
     arg_types["realtime"]        = "bool";
+    arg_types["no-time-travel"]  = "bool";
     arg_types["colour-images"]   = "bool";
     arg_types["hide-date"]       = "bool";
     arg_types["hide-files"]      = "bool";
@@ -355,6 +358,7 @@ void GourceSettings::setGourceDefaults() {
     stop_on_idle   = false;
     stop_at_end    = false;
     dont_stop      = false;
+    no_time_travel = false;
 
     show_key = false;
 
@@ -1192,6 +1196,10 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
 
     if(gource_settings->getBool("realtime")) {
         days_per_second = 1.0 / 86400.0;
+    }
+
+    if(gource_settings->getBool("no-time-travel")) {
+        no_time_travel = true;
     }
 
     if(gource_settings->getBool("dont-stop")) {

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -67,6 +67,7 @@ public:
     bool stop_on_idle;
     bool stop_at_end;
     bool dont_stop;
+    bool no_time_travel;
 
     float auto_skip_seconds;
     float days_per_second;


### PR DESCRIPTION
Enabling this option causes gource to use the time of the
parent commit, if the time of a commit is in the past.
This allows a linear simulation, even if the time of the
commits are not corresponding to the order of the commits.

#167 