### PR TITLE
Made no-time-travel more robust.

### DIFF
--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1116,8 +1116,8 @@ void Gource::readLog() {
 
         if(gGourceSettings.no_time_travel) {
             time_t check_time = commitqueue.empty() ? lasttime : commitqueue.back().timestamp;
-            if(commit.timestamp < check_time) {
-                commit.timestamp = check_time;
+            if(commit.timestamp <= check_time) {
+                commit.timestamp = check_time + 1;
             }
         }
 


### PR DESCRIPTION
Avoid two commits with the same timestamp when using
no-time-travel. Since 5ec56acb this helps to avoid
cancelling a file removal.

I never had the issues this change try to avoid. But while I was
thinking about the last changes this situation came in my mind.