### PR TITLE
Fix #190 (force not showing signatures in the log).

### DIFF
--- a/src/formats/git.cpp
+++ b/src/formats/git.cpp
@@ -28,6 +28,7 @@
 std::string GitCommitLog::logCommand() {
 
     std::string log_command = "git log "
+    "--no-show-signature "
     "--pretty=format:user:%aN%n%ct "
     "--reverse --raw --encoding=UTF-8 "
     "--no-renames";

--- a/src/formats/gitraw.cpp
+++ b/src/formats/gitraw.cpp
@@ -26,7 +26,7 @@ Regex git_raw_file("^:[0-9]+ [0-9]+ [0-9a-z]+\\.* ([0-9a-z]+)\\.* ([A-Z])[ \\t]+
 
 // parse git log entries
 
-std::string gGourceGitRawLogCommand = "git log --reverse --raw --pretty=raw";
+std::string gGourceGitRawLogCommand = "git log --no-show-signature --reverse --raw --pretty=raw";
 
 GitRawCommitLog::GitRawCommitLog(const std::string& logfile) : RCommitLog(logfile, 'c') {
 


### PR DESCRIPTION
Add `--no-show-signature` to the git command in git.cpp and gitraw.cpp.