### PR TITLE
Add an option to disable keyboard and mouse input

### DIFF
--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -319,6 +319,7 @@ void Gource::grabMouse(bool grab_mouse) {
 
 void Gource::mouseMove(SDL_MouseMotionEvent *e) {
     if(commitlog==0) return;
+    if(gGourceSettings.disable_input) return;
     if(gGourceSettings.hide_mouse) return;
 
     if(grab_mouse) {
@@ -399,6 +400,7 @@ void Gource::zoom(bool zoomin) {
 
 #if SDL_VERSION_ATLEAST(2,0,0)
 void Gource::mouseWheel(SDL_MouseWheelEvent *e) {
+    if(gGourceSettings.disable_input) return;
 
     if(e->y > 0) {
         zoom(true);
@@ -413,6 +415,7 @@ void Gource::mouseWheel(SDL_MouseWheelEvent *e) {
 
 void Gource::mouseClick(SDL_MouseButtonEvent *e) {
     if(commitlog==0) return;
+    if(gGourceSettings.disable_input) return;
     if(gGourceSettings.hide_mouse) return;
 
     //mouse click should stop the cursor being idle
@@ -630,6 +633,8 @@ void Gource::selectNextUser() {
 }
 
 void Gource::keyPress(SDL_KeyboardEvent *e) {
+    if (gGourceSettings.disable_input) return;
+
     if (e->type == SDL_KEYUP) return;
 
     if (e->type == SDL_KEYDOWN) {

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -117,6 +117,8 @@ if(extended_help) {
 
     printf("  --disable-auto-rotate    Disable automatic camera rotation\n\n");
 
+    printf("  --disable-input          Disable keyboard and mouse input\n\n");
+
     printf("  --date-format FORMAT     Specify display date string (strftime format)\n\n");
 
     printf("  --font-file FILE         Specify the font\n");
@@ -265,6 +267,7 @@ GourceSettings::GourceSettings() {
 
     arg_types["disable-auto-rotate"] = "bool";
     arg_types["disable-auto-skip"]   = "bool";
+    arg_types["disable-input"]       = "bool";
 
     arg_types["git-log-command"]= "bool";
     arg_types["cvs-exp-command"]= "bool";
@@ -377,6 +380,8 @@ void GourceSettings::setGourceDefaults() {
     show_key = false;
 
     disable_auto_rotate = false;
+
+    disable_input = false;
 
     auto_skip_seconds = 3.0f;
     days_per_second   = 0.1f; // TODO: check this is right
@@ -669,6 +674,10 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
 
     if(gource_settings->getBool("disable-auto-skip")) {
         auto_skip_seconds = -1.0;
+    }
+
+    if(gource_settings->getBool("disable-input")) {
+        disable_input=true;
     }
 
     if(gource_settings->getBool("loop")) {

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -44,6 +44,8 @@ public:
 
     bool disable_auto_rotate;
 
+    bool disable_input;
+
     bool show_key;
 
     std::string load_config;


### PR DESCRIPTION
For use in automated rendering, it would be ideal if keyboard and
mouse input could not accidentally disturb the application.