### PR TITLE
Added --user-font-size, --filename-font-size, and --dirname-font-size arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@
  * Added --user-show-filter option (Victor Lopez).
  * Added --disable-input option (Joey Parrish).
  * Added --loop-delay-seconds option (Joey Parrish).
+ * Added --filename-font-size, --dirname-font-size, and --user-font-size options (Carl Colena).
  * Fixed a bug in the Mercurial log parser that caused changes to be missed.
  * Fixed file removal being cancelled by an action with an earlier timestamp.
  * Fixed a bug in the log file format detection that could result in the wrong

--- a/README
+++ b/README
@@ -143,6 +143,15 @@ options:
     --font-size SIZE
             Font size used by the date and title.
 
+    --filename-font-size SIZE
+            Font size of filenames.
+
+    --dirname-font-size SIZE
+            Font size of directory names
+
+    --user-font-size SIZE
+            Font size of user names.
+
     --font-colour FFFFFF
             Font colour used by the date and title in hex.
 

--- a/data/gource.1
+++ b/data/gource.1
@@ -106,6 +106,15 @@ Specify the font. Should work with most font file formats supported by FreeType,
 \fB\-\-font\-size SIZE\fR
 Font size used by the date and title.
 .TP
+\fB\-\-filename\-font\-size SIZE\fR
+Font size of filenames.
+.TP
+\fB\-\-dirname\-font\-size SIZE\fR
+Font size of directory names.
+.TP
+\fB\-\-user\-font\-size SIZE\fR
+Font size of user names.
+.TP
 \fB\-\-font\-colour FFFFFF\fR
 Font colour used by the date and title in hex.
 .TP

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -59,7 +59,7 @@ RFile::RFile(const std::string & name, const vec3 & colour, const vec2 & pos, in
     }
 
     if(!file_font.initialized()) {
-        file_font = fontmanager.grab(gGourceSettings.font_file, 14);
+        file_font = fontmanager.grab(gGourceSettings.font_file, gGourceSettings.filename_font_size);
         file_font.dropShadow(true);
         file_font.roundCoordinates(false);
         file_font.setColour(vec4(gGourceSettings.filename_colour, 1.0f));

--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -53,6 +53,10 @@ Gource::Gource(FrameExporter* exporter) {
     font.dropShadow(true);
     font.roundCoordinates(true);
 
+    fontdirname = fontmanager.grab(gGourceSettings.font_file, gGourceSettings.dirname_font_size);
+    fontdirname.dropShadow(true);
+    fontdirname.roundCoordinates(true);
+
     //only use bloom with alpha channel if transparent due to artifacts on some video cards
     std::string bloom_tga = gGourceSettings.transparent ? "bloom_alpha.tga" : "bloom.tga";
 
@@ -2452,10 +2456,10 @@ void Gource::draw(float t, float dt) {
         fontmanager.startBuffer();
     }
 
-    font.roundCoordinates(false);
-    font.setColour(vec4(gGourceSettings.dir_colour, 1.0f));
+    fontdirname.roundCoordinates(false);
+    fontdirname.setColour(vec4(gGourceSettings.dir_colour, 1.0f));
 
-    root->drawNames(font);
+    root->drawNames(fontdirname);
 
    if(!(gGourceSettings.hide_usernames || gGourceSettings.hide_users)) {
         for(std::map<std::string,RUser*>::iterator it = users.begin(); it!=users.end(); it++) {

--- a/src/gource.h
+++ b/src/gource.h
@@ -130,7 +130,7 @@ class Gource : public SDLApp {
 
     TextBox textbox;
 
-    FXFont font, fontlarge, fontmedium, fontcaption;
+    FXFont font, fontlarge, fontmedium, fontcaption, fontdirname;
 
     bool first_read;
     bool paused;

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -121,12 +121,12 @@ if(extended_help) {
 
     printf("  --date-format FORMAT     Specify display date string (strftime format)\n\n");
 
-    printf("  --font-file FILE         Specify the font\n");
-    printf("  --font-size SIZE         Font size used by date and title\n");
-    printf("  --filename-font-size SIZE         Font size for filenames\n");
-    printf("  --dirname-font-size SIZE         Font size for directory names\n");
-    printf("  --user-font-size SIZE    Font size for user names\n");
-    printf("  --font-colour FFFFFF     Font colour used by date and title in hex\n\n");
+    printf("  --font-file FILE              Specify the font\n");
+    printf("  --font-size SIZE              Font size used by date and title\n");
+    printf("  --filename-font-size SIZE     Font size for filenames\n");
+    printf("  --dirname-font-size SIZE      Font size for directory names\n");
+    printf("  --user-font-size SIZE         Font size for user names\n");
+    printf("  --font-colour FFFFFF          Font colour used by date and title in hex\n\n");
 
     printf("  --file-extensions          Show filename extensions only\n");
     printf("  --file-extension-fallback  Use filename as extension if the extension\n");

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -123,6 +123,9 @@ if(extended_help) {
 
     printf("  --font-file FILE         Specify the font\n");
     printf("  --font-size SIZE         Font size used by date and title\n");
+    printf("  --filename-font-size SIZE         Font size for filenames\n");
+    printf("  --dirname-font-size SIZE         Font size for directory names\n");
+    printf("  --user-font-size SIZE    Font size for user names\n");
     printf("  --font-colour FFFFFF     Font colour used by date and title in hex\n\n");
 
     printf("  --file-extensions          Show filename extensions only\n");
@@ -293,6 +296,9 @@ GourceSettings::GourceSettings() {
 
     arg_types["max-files"] = "int";
     arg_types["font-size"] = "int";
+    arg_types["filename-font-size"] = "int";
+    arg_types["dirname-font-size"] = "int";
+    arg_types["user-font-size"] = "int";
     arg_types["hash-seed"] = "int";
 
     arg_types["user-filter"]      = "multi-value";
@@ -422,6 +428,9 @@ void GourceSettings::setGourceDefaults() {
 
     font_file = GOURCE_FONT_FILE;
     font_size = 16;
+    filename_font_size = 14;
+    dirname_font_size = 14;
+    user_font_size = 14;
     dir_colour       = vec3(1.0f);
     font_colour      = vec3(1.0f);
     highlight_colour = vec3(1.0f);
@@ -963,6 +972,39 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
         font_size = entry->getInt();
 
         if(font_size<1 || font_size>100) {
+            conffile.invalidValueException(entry);
+        }
+    }
+
+    if((entry = gource_settings->getEntry("filename-font-size")) != 0) {
+
+        if(!entry->hasValue()) conffile.entryException(entry, "specify font size");
+
+        filename_font_size = entry->getInt();
+
+        if(filename_font_size<1 || filename_font_size>100) {
+            conffile.invalidValueException(entry);
+        }
+    }
+
+    if((entry = gource_settings->getEntry("dirname-font-size")) != 0) {
+
+        if(!entry->hasValue()) conffile.entryException(entry, "specify font size");
+
+        dirname_font_size = entry->getInt();
+
+        if(dirname_font_size<1 || dirname_font_size>100) {
+            conffile.invalidValueException(entry);
+        }
+    }
+
+    if((entry = gource_settings->getEntry("user-font-size")) != 0) {
+
+        if(!entry->hasValue()) conffile.entryException(entry, "specify font size");
+
+        user_font_size = entry->getInt();
+
+        if(user_font_size<1 || user_font_size>100) {
             conffile.invalidValueException(entry);
         }
     }

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -105,6 +105,9 @@ public:
 
     std::string font_file;
     int font_size;
+    int filename_font_size;
+    int dirname_font_size;
+    int user_font_size;
     vec3 font_colour;
 
     float elasticity;

--- a/src/user.cpp
+++ b/src/user.cpp
@@ -308,7 +308,7 @@ void RUser::updateFont() {
         font = fontmanager.grab(gGourceSettings.font_file, 18);
         font.dropShadow(true);
     } else {
-        font = fontmanager.grab(gGourceSettings.font_file, 14);
+        font = fontmanager.grab(gGourceSettings.font_file, gGourceSettings.user_font_size);
         font.dropShadow(true);
     }
 


### PR DESCRIPTION
Added 3 new arguments to independently adjust the font size of the filenames, user names, and directory names. This was needed when it was observed under very high resolutions (4k) that the font sizes did not scale, and that there was no way to modify them without recompilation.

The directory name argument was a bit tricky to handle, but I think I was able to cover it with an additional instance var in Gource.cpp so the other font sizes wouldn't be affected.

Tested and working with the same defaults as was previously written.