### PR TITLE
Fixed filenames not being affected by --font-scale

### DIFF
--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -1029,9 +1029,10 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
             conffile.invalidValueException(entry);
         }
 
-        font_size         = glm::clamp((int)(font_size * font_scale), 1, 100);
-        user_font_size    = glm::clamp((int)(user_font_size * font_scale), 1, 100);
-        dirname_font_size = glm::clamp((int)(dirname_font_size * font_scale), 1, 100);
+        font_size           = glm::clamp((int)(font_size * font_scale), 1, 100);
+        user_font_size      = glm::clamp((int)(user_font_size * font_scale), 1, 100);
+        dirname_font_size   = glm::clamp((int)(dirname_font_size * font_scale), 1, 100);
+        filename_font_size  = glm::clamp((int)(filename_font_size * font_scale), 1, 100);
     }    
 
     if((entry = gource_settings->getEntry("hash-seed")) != 0) {


### PR DESCRIPTION
Noticed that `--font-scale` clamped all but the filename font size, so I just added it to the list to patch the bug.