### PR TITLE
Adds ability to dynamically adjust seconds-per-day.

### DIFF
--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1725,6 +1725,12 @@ void Gource::logic(float t, float dt) {
             idle_time = 0.0;
         }
 
+        if(gGourceSettings.transitions.size() > 0 && commit.timestamp > gGourceSettings.transitions.front()) {
+            gGourceSettings.days_per_second = gGourceSettings.days_per_second_list.front();
+            gGourceSettings.days_per_second_list.pop_front();
+            gGourceSettings.transitions.pop_front();
+        }
+
         if(commit.timestamp > currtime) break;
 
         processCommit(commit, t);

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -24,6 +24,8 @@
 #include "core/settings.h"
 #include "core/regex.h"
 
+#include <deque>
+
 class GourceSettings : public SDLAppSettings {
 protected:
     void commandLineOption(const std::string& name, const std::string& value);
@@ -145,6 +147,8 @@ public:
     std::vector<Regex*> file_show_filters;
     std::vector<Regex*> user_filters;
     std::vector<Regex*> user_show_filters;
+    std::deque<float> days_per_second_list;
+    std::deque<time_t> transitions;
     bool file_extensions;
     bool file_extension_fallback;
 

--- a/src/gource_shell.cpp
+++ b/src/gource_shell.cpp
@@ -197,8 +197,6 @@ Gource* GourceShell::getNext() {
         return 0;
     }
 
-    gGourceSettings.importGourceSettings(*conf, *gource_settings);
-
     //recording a video kind of implies you want this, unless:
     // -- dont stop requested
     // -- loop requested


### PR DESCRIPTION
With this change, a user can:

1. Specify multiple seconds per day parameters.
2. Specify transition timestamps when to switch to the next seconds per day parameter.

Things to note:

* When specifying transition, it will check that the number of seconds per day parameters is N + 1, where N is number of transitions.
* Gource was importing settings twice. So I removed the second one. Importing settings is currently not idempotent .. multi-value parameters will add items twice. This was not detected before because previous parameters were independent and it didn't matter if there were duplicates.

Future ideas to consider:

Figuring out what values to set for `--seconds-per-day` is complex. The system will invert the value and create a days per second calculation. I eventually found the following formula works well and comes super close to what I want:

<img src="https://render.githubusercontent.com/render/math?math=\large \dfrac {1} { \dfrac  { \color {red} 3229}  { \color {orange} 127} \left(2.5 \left(\dfrac {122}  {127}\right)\right)}">

```diff
- The red parameter is the number of days.
! The orange parameter is the number of seconds.
```
The coefficient <img src="https://render.githubusercontent.com/render/math?math=\left(2.5 \left(\dfrac {122}  {127}\right)\right)"> was tuned after trial and error. Getting to it is probably dependent on the performance of the machine and the complexity of the graph being rendered. Even though the denominators are the same in this example, the 127 in the fudging coefficient remains constant when specifying other lengths of time.

I think a better user experience would be to specify ranges of days and how many seconds they should run in. I would need to study the code more to figure out the ticks / frames aspects, but this may be hard to guarantee with accuracy depending on the system rendering and graph complexity.

For now, this patch provides a powerful way to dynamically dilate the time across different time ranges. If there are ideas around the better experience and getting the timing right for all level of complexities and machine performance, we can work on that instead.
