### PR TITLE
Adds --first-parent options to remove previously deleted files

### DIFF
--- a/src/formats/git.cpp
+++ b/src/formats/git.cpp
@@ -89,7 +89,7 @@ std::string GitCommitLog::logCommand() {
 
     std::string log_command = "git log "
     "--pretty=format:user:%aN%n%ct "
-    "--reverse --raw --encoding=UTF-8 "
+    "--reverse --raw --encoding=UTF-8 --first-parent "
     "--no-renames";
 
     readGitVersion();


### PR DESCRIPTION
This option stops commits from having multiple parents in the git log, which fixes the error where previously deleted or moved files still show up in the graph.

This is pretty much the same thing that the command posted by @FlorianWilhelm on #66 

`git filter-branch --parent-filter 'cut -f 2,3 -d " "'` selects only the first parent.

This seems like a good and most important of all, simple and easy to maintain solution to the problem.