### PR TITLE
Fix build with Boost 1.85.0

### DIFF
--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -833,7 +833,7 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
 #else
             dirfile = p.filename().string();
 #endif
-            std::string file_ext = extension(p);
+            std::string file_ext = p.extension().string();
             boost::algorithm::to_lower(file_ext);
 
             if(file_ext != ".jpg" && file_ext != ".jpeg" && file_ext != ".png") continue;


### PR DESCRIPTION
Build was failing with Boost 1.85.0:
```
src/gource_settings.cpp:836:36: error: use of undeclared identifier 'extension'
            std::string file_ext = extension(p);
                                   ^
1 error generated.
```

Looking at https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/deprecated.html, it appears the `extension()` was removed with recommendation:
> Replace `extension(p)` with `p.extension().string()`.

I see oldest support Boost in https://github.com/acaudwell/Gource/blob/master/INSTALL#L21 is 1.46.

Taking a look at https://www.boost.org/doc/libs/1_46_0/boost/filesystem/convenience.hpp, as long as code isn't setting `BOOST_FILESYSTEM_VERSION == 2`, it looks like `extension()` was just an alias, i.e.
```hpp
    inline std::string extension(const path & p)
    {
      return p.extension().string();
    }
```

---

Seen while updating Boost in Homebrew - https://github.com/Homebrew/homebrew-core/pull/169237