### PR TITLE
Add building of AppImages for Releases

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -20,7 +20,7 @@ jobs:
             build-essential cmake libsdl2-dev libpcre3-dev libglew-dev \
             libglm-dev libboost-filesystem-dev libfreetype6-dev libpng-dev \
             libjpeg-dev libfftw3-dev libvorbis-dev libopenal-dev libxrandr-dev \
-            libxi-dev libsdl2-* libfuse libfuse-dev
+            libxi-dev libsdl2-* libfuse-dev
 
       - name: Build Gource
         run: |

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -57,3 +57,10 @@ jobs:
         with:
           name: Gource.AppImage
           path: Gource-x86_64.AppImage
+
+      - name: Upload AppImage to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: Gource-x86_64.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -1,0 +1,63 @@
+
+name: Build Gource AppImage
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake libsdl2-dev libpcre3-dev libglew-dev \
+            libglm-dev libboost-filesystem-dev libfreetype6-dev libpng-dev \
+            libjpeg-dev libfftw3-dev libvorbis-dev libopenal-dev libxrandr-dev \
+            libxi-dev libsdl2-* libfuse libfuse-dev
+
+      - name: Build Gource
+        run: |
+          ./autogen.sh
+          ./configure
+          make
+
+      - name: Download linuxdeploy
+        run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+
+      - name: Bundle dependencies with linuxdeploy
+        run: |
+          ./linuxdeploy-x86_64.AppImage --appdir AppDir --executable AppDir/usr/bin/gource --desktop-file AppDir/gource.desktop --icon-file AppDir/gource.png --output appimage
+
+      - name: Prepare AppDir
+        run: |
+          mkdir -p AppDir/usr/bin
+          cp gource AppDir/usr/bin/
+          mkdir -p AppDir/usr/share/gource
+          cp -r data/* AppDir/usr/share/gource/
+          echo "[Desktop Entry]
+          Name=Gource
+          Exec=gource
+          Icon=gource
+          Type=Application
+          Categories=Graphics;Development;
+          Comment=Software version control visualization tool" > AppDir/gource.desktop
+          cp data/file.png AppDir/gource.png
+
+      - name: Create AppImage
+        run: |
+          ./appimagetool-x86_64.AppImage AppDir
+
+      - name: Upload AppImage as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Gource.AppImage
+          path: Gource-x86_64.AppImage

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -33,10 +33,6 @@ jobs:
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
 
-      - name: Bundle dependencies with linuxdeploy
-        run: |
-          ./linuxdeploy-x86_64.AppImage --appdir AppDir --executable AppDir/usr/bin/gource --desktop-file AppDir/gource.desktop --icon-file AppDir/gource.png --output appimage
-
       - name: Prepare AppDir
         run: |
           mkdir -p AppDir/usr/bin
@@ -52,9 +48,9 @@ jobs:
           Comment=Software version control visualization tool" > AppDir/gource.desktop
           cp data/file.png AppDir/gource.png
 
-      - name: Create AppImage
+      - name: Bundle dependencies with linuxdeploy
         run: |
-          ./appimagetool-x86_64.AppImage AppDir
+          ./linuxdeploy-x86_64.AppImage --appdir AppDir --executable AppDir/usr/bin/gource --desktop-file AppDir/gource.desktop --icon-file AppDir/gource.png --output appimage
 
       - name: Upload AppImage as an artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
What started with discussion #335 about creating an AppImage for Gource has now become an automated build workflow to generate one for every Gource release. This AppImage is distro agnostic and should work across most all linux-based platforms, including immutable and atomic distros such as Bazzite (tested myself), Fedora Silverblue, Micro OS, SteamOS, etc. The AppImage is called with `./Gource-x86_64.AppImage` and has access to all of the normal parameters that Gource has when called normally. Users can create aliases for the AppImage to even have it be called with the regular `Gource` if desired. With the growth in immutable and atomic distros, having access to programs like this without having access to the system files is useful. It also solves issues for any distros that might not package Gource in their repos, saving folks the trouble of needing to compile from source to use it.

Be curious to know what the thoughts are on this! Feel free to download the AppImage I generated on my fork and try it out. It should work across most Linux systems, but always good to get feedback on any possible issues too. :)