### PR TITLE
Fix --stop-at-end for piped input

### DIFF
--- a/src/formats/commitlog.cpp
+++ b/src/formats/commitlog.cpp
@@ -236,7 +236,7 @@ bool RCommitLog::nextCommit(RCommit& commit, bool validate) {
 }
 
 bool RCommitLog::isFinished() {
-    if(seekable && logf->isFinished()) return true;
+    if(logf->isFinished()) return true;
 
     return false;
 }


### PR DESCRIPTION
The `--stop-at-end` flag doesn't work when piping input.

```
$(gource --log-command git) > repo.log

# Exits as expected
gource --stop-at-end repo.log

# Never exits
cat repo.log | gource --stop-at-end - 
```

After building with this change and https://github.com/acaudwell/Core/pull/14, we can see:

```
$(gource --log-command git) > repo.log

# Exits as expected
gource --stop-at-end repo.log

# Exits as expected
cat repo.log | gource --stop-at-end - 

# Never exits (as expected)
tail -f repo.log | gource --stop-at-end - 
```