### PR TITLE
Add subtitle export feature with correct time-scale handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ options:
             Hide one or more display elements from the list below:
 
             bloom     - bloom effect
+            captions  - caption text
             date      - current date
             dirnames  - names of directories
             files     - file icons
@@ -326,6 +327,10 @@ options:
 
     --caption-offset X
             Caption horizontal offset (0 to centre captions).
+
+    --caption-export FILE
+            Export captions to subtitle file (SRT or WebVTT format).
+            File format is determined by extension (.srt or .vtt/.webvtt).
 
     -o, --output-ppm-stream FILE
             Output a PPM image stream to a file ('-' for STDOUT).

--- a/data/gource.1
+++ b/data/gource.1
@@ -268,6 +268,7 @@ Disable keyboard and mouse input.
 Hide one or more display elements from the list below:
 
     bloom     \- bloom effect
+    captions  \- caption text
     date      \- current date
     dirnames  \- names of directories
     files     \- file icons
@@ -299,6 +300,10 @@ Caption duration.
 .TP
 \fB\-\-caption-offset X
 Caption horizontal offset (0 to centre captions).
+.TP
+\fB\-\-caption-export FILE
+Export captions to subtitle file (SRT or WebVTT format).
+File format is determined by extension (.srt or .vtt/.webvtt).
 .TP
 \fB\-o, \-\-output\-ppm\-stream FILE\fR
 Output a PPM image stream to a file ('\-' for STDOUT).

--- a/src/gource.h
+++ b/src/gource.h
@@ -145,6 +145,7 @@ class Gource : public SDLApp {
     time_t currtime;
     time_t lasttime;
     float runtime;
+    float video_time;  // Unscaled time for subtitle export
     float subseconds;
 
     float splash;
@@ -185,6 +186,11 @@ class Gource : public SDLApp {
 
     std::list<RCaption*> captions;
     std::list<RCaption*> active_captions;
+    
+    // Subtitle export tracking
+    std::ofstream* subtitle_export_stream;
+    int subtitle_export_index;
+    std::map<RCaption*, float> caption_start_times;
 
     QuadTree* dirNodeTree;
     QuadTree* userTree;
@@ -208,6 +214,8 @@ class Gource : public SDLApp {
     void selectNextUser();
 
     void loadCaptions();
+    void exportCaptions();
+    void writeSubtitleEntry(RCaption* caption, float start_time, float end_time);
 
     void readLog();
 

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -180,6 +180,7 @@ if(extended_help) {
     printf("  --filename-time SECONDS  Duration to keep filenames on screen (default: 4.0)\n\n");
 
     printf("  --caption-file FILE         Caption file\n");
+    printf("  --caption-export FILE       Export captions to file (SRT or WebVTT format)\n");
     printf("  --caption-size SIZE         Caption font size\n");
     printf("  --caption-colour FFFFFF     Caption colour in hex\n");
     printf("  --caption-duration SECONDS  Caption duration (default: 10.0)\n");
@@ -271,6 +272,7 @@ GourceSettings::GourceSettings() {
     arg_types["hide-bloom"]              = "bool";
     arg_types["hide-mouse"]              = "bool";
     arg_types["hide-root"]               = "bool";
+    arg_types["hide-captions"]           = "bool";
     arg_types["highlight-users"]         = "bool";
     arg_types["highlight-dirs"]          = "bool";
     arg_types["file-extensions"]         = "bool";
@@ -354,6 +356,7 @@ GourceSettings::GourceSettings() {
     arg_types["dir-colour"]         = "string";
 
     arg_types["caption-file"]       = "string";
+    arg_types["caption-export"]     = "string";
     arg_types["caption-size"]       = "int";
     arg_types["caption-duration"]   = "float";
     arg_types["caption-colour"]     = "string";
@@ -383,6 +386,7 @@ void GourceSettings::setGourceDefaults() {
     hide_bloom     = false;
     hide_mouse     = false;
     hide_root      = false;
+    hide_captions  = false;
 
     start_timestamp = 0;
     start_date = "";
@@ -478,6 +482,7 @@ void GourceSettings::setGourceDefaults() {
     highlight_dirs = false;
 
     caption_file     = "";
+    caption_export_file = "";
     caption_duration = 10.0f;
     caption_size     = 16;
     caption_offset   = 0;
@@ -695,6 +700,7 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
             else if(hidestr == "bloom")     hide_bloom     = true;
             else if(hidestr == "progress")  hide_progress  = true;
             else if(hidestr == "root")      hide_root      = true;
+            else if(hidestr == "captions")  hide_captions  = true;
             else if(hidestr == "mouse")     {
                 hide_mouse     = true;
                 hide_progress  = true;
@@ -872,6 +878,13 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
         if(!boost::filesystem::exists(caption_file)) {
             conffile.entryException(entry, "caption file not found");
         }
+    }
+
+    if((entry = gource_settings->getEntry("caption-export")) != 0) {
+
+        if(!entry->hasValue()) conffile.entryException(entry, "specify caption export file (filename)");
+
+        caption_export_file = entry->getString();
     }
 
     if((entry = gource_settings->getEntry("caption-duration")) != 0) {

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -41,6 +41,7 @@ public:
     bool hide_bloom;
     bool hide_mouse;
     bool hide_root;
+    bool hide_captions;
 
     bool disable_auto_rotate;
 
@@ -156,6 +157,7 @@ public:
     bool file_extension_fallback;
 
     std::string caption_file;
+    std::string caption_export_file;
     vec3 caption_colour;
     float caption_duration;
     int caption_size;


### PR DESCRIPTION
- Add --caption-export option to export subtitles to SRT/WebVTT files
- Add --hide-captions option to hide captions while still exporting
- Track video_time separately from runtime for correct subtitle timing
- Support different framerates (25/30/60 fps) for video export
- Maintain subtitle sync regardless of time-scale setting

The implementation correctly handles the difference between simulation time (affected by --time-scale) and actual video playback time, ensuring that exported subtitles always sync with the video output.

Supported formats:
- SRT (.srt) - SubRip format
- WebVTT (.vtt, .webvtt) - Web Video Text Tracks format

Usage examples:
  gource --caption-file captions.txt --caption-export output.srt 
  gource --caption-file captions.txt --hide-captions --caption-export output.vtt