### PR TITLE
Add user parking feature with configurable settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,47 @@ options:
     --user-scale SCALE
             Change scale of user avatars.
 
+    --park-idle-users
+            Park inactive users at the screen edge instead of removing them.
+
+    --park-immediate
+            Park users as soon as they become idle (implies --park-idle-users).
+
+    --park-lock-slots
+            Prevent parked users from shifting when a slot before them becomes
+            free. Empty slots can be reused by any user.
+
+    --park-position POSITION
+            Position of parking area (bottom, top, left, right).
+            Default: bottom.
+
+    --park-direction DIRECTION
+            Fill direction for parking slots (forward, reverse).
+            Default: forward.
+
+    --park-rows ROWS
+            Number of rows for parked users. Use 0 for auto. Default: 1.
+
+    --park-round-robin
+            Distribute users across rows in round-robin order instead of
+            filling each row completely before starting the next.
+
+    --park-y-offset PIXELS
+            Distance from the screen edge for the parking area. Default: 0.
+
+    --park-spacing PIXELS
+            Spacing between parked users. Default: 0 (auto).
+
+    --park-scale SCALE
+            Scale of parked user avatars. Default: 0.5.
+
+    --park-opacity FLOAT
+            Opacity of parked users (0.0 to 1.0). Default: 0.5.
+
+    --park-speed-factor FLOAT
+            Speed multiplier for users traveling to parking spots.
+            Default: 0.5.
+
     --camera-mode MODE
             Camera mode (overview,track).
 

--- a/src/gource.h
+++ b/src/gource.h
@@ -21,6 +21,7 @@
 #include <deque>
 #include <list>
 #include <fstream>
+#include <unordered_map>
 
 #include "core/display.h"
 #include "core/shader.h"
@@ -189,6 +190,10 @@ class Gource : public SDLApp {
     QuadTree* dirNodeTree;
     QuadTree* userTree;
 
+    // Parking area management
+    std::vector<RUser*> parked_users;
+    std::unordered_map<RUser*, size_t> parking_slot_index;
+
     std::string message;
     float message_timer;
 
@@ -224,6 +229,11 @@ class Gource : public SDLApp {
 
     void updateUsers(float t, float dt);
     void updateDirs(float dt);
+
+    void parkUser(RUser* user);
+    void unparkUser(RUser* user);
+    vec2 calcParkingPosition(int slot);
+    void recalcParkingPositions();
 
     void interactUsers();
     void interactDirs();

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -136,6 +136,20 @@ public:
     float user_scale;
     float time_scale;
 
+    bool park_idle_users;
+    bool park_immediate;
+    bool park_lock_slots;
+    float park_y_offset;
+    float park_spacing;
+    float park_opacity;
+    float park_scale;
+    float park_speed_factor;
+    int park_rows;
+    bool park_round_robin;
+    enum ParkPosition { PARK_BOTTOM, PARK_TOP, PARK_LEFT, PARK_RIGHT };
+    ParkPosition park_position;
+    bool park_direction_reverse;
+
     bool highlight_dirs;
     bool highlight_all_users;
 

--- a/src/user.h
+++ b/src/user.h
@@ -52,6 +52,18 @@ class RUser : public Pawn {
 
     bool highlighted;
 
+    // Parking constants
+    static constexpr float PARKING_ARRIVAL_THRESHOLD = 5.0f;
+    static constexpr float BASE_USER_SIZE = 20.0f;
+
+    // Parking state
+    bool parked;
+    bool parking;
+    vec2 parking_target;
+    vec2 pre_park_pos;
+    float parked_size;
+    float parking_start_dist;
+
     bool nameVisible() const;
 
     void updateFont();
@@ -71,6 +83,17 @@ public:
     bool isIdle();
     bool isFading();
     bool isInactive();
+
+    bool isParked() const { return parked; }
+    bool isParking() const { return parking; }
+    static float parkingArrivalThreshold() { return PARKING_ARRIVAL_THRESHOLD; }
+    void park(const vec2& target);
+    void unpark();
+    void updateParkingTarget(const vec2& target);
+    void snapToParkingTarget(const vec2& target);
+    float parkingDistance() const;
+    void forceParkSnap();
+    vec2 getParkingTarget() const { return parking_target; }
 
     void setSelected(bool selected);
     void setHighlighted(bool highlighted);


### PR DESCRIPTION
Add option to park idle users at screen edges instead of removing them

### New Options

- `--park-idle-users` - Enable parking (move idle users to screen edge instead of removing)
- `--park-immediate` - Park users as soon as they go idle
- `--park-lock-slots` - Keep parking slots reserved once claimed
- `--park-position POSITION` - Where to park: `bottom`, `top`, `left`, or `right`
- `--park-direction-reverse` - Reverse the fill direction
- `--park-y-offset PIXELS` - Distance from the screen edge (default: 0)
- `--park-spacing PIXELS` - Spacing between parked users (0 = auto)
- `--park-opacity FLOAT` - Opacity of parked users (default: 0.5)
- `--park-scale SCALE` - Scale of parked users (default: 0.5)
- `--park-speed-factor F` - Speed multiplier while parking (default: 0.5)
- `--park-rows ROWS` - Number of rows for parked users (0 = auto, default: 1)
- `--park-round-robin` - Distribute users across rows in round-robin order

Example:
```
./gource -s 0.1 --park-scale 0.5 --park-opacity 0.5 --park-rows 2  --park-position bottom --park-immediate --park-lock-slots  --park-round-robin ./
```

https://github.com/user-attachments/assets/ae060a70-66d0-4fdd-a862-552012599ec0

Example with user images, as the main point of this is to keep showing contributers
```
./gource -s 0.1 --park-idle-users --park-scale 0.5 --park-opacity 0.5 --park-rows 2  --park-position bottom --park-lock-slots  --park-round-robin --park-immediate --user-image-dir ./avatars2/ ./
```

https://github.com/user-attachments/assets/a6c2b779-a377-4582-b282-c6d7eb8865ca


