### PR TITLE
Fix bzr file renames not being tracked

### DIFF
--- a/src/formats/bzr.cpp
+++ b/src/formats/bzr.cpp
@@ -118,7 +118,24 @@ bool BazaarLog::parseCommit(RCommit& commit) {
 
     while(logf->getNextLine(line) && line.size()) {
         if (!bzr_file_regex.match(line, &entries)) continue;
-        commit.addFile(entries[1], entries[0]);
+
+        std::string action   = entries[0];
+        std::string filename = entries[1];
+
+        if(action == "R") {
+            // Rename: "old_path => new_path"
+            size_t arrow = filename.find(" => ");
+            if(arrow != std::string::npos) {
+                std::string old_path = filename.substr(0, arrow);
+                std::string new_path = filename.substr(arrow + 4);
+                commit.addFile(old_path, "D");
+                commit.addFile(new_path, "A");
+            } else {
+                commit.addFile(filename, "A");
+            }
+        } else {
+            commit.addFile(filename, action);
+        }
     }
 
     return true;


### PR DESCRIPTION
## Summary
- Fixes file renames (`bzr mv`) not being visualized correctly in Gource
- When Bazaar logs a rename, it outputs `R  old_path => new_path`. Previously this was treated as a modify on the raw string, so moves were invisible in the visualization
- Splits rename entries into a **delete** of the old path and an **add** of the new path, matching how other VCS parsers handle renames

Fixes #38

## Test plan
- [ ] Run Gource against a Bazaar repo containing file renames (`bzr mv`)
- [ ] Verify renamed files disappear from old location and appear at new location in the visualization
- [ ] Verify normal add/modify/delete operations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)