### PR TITLE
Add --commit-interval option for fixed-interval playback

### DIFF
--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -918,6 +918,9 @@ void Gource::reset() {
 
     commitqueue_max_size = 100;
 
+    commit_interval_count = 0;
+    commit_interval_base  = 0;
+
     rotate_angle = 0.0f;
 
     if(root!=0) delete root;
@@ -1143,6 +1146,14 @@ void Gource::readLog() {
                 break;
             }
             continue;
+        }
+
+        if(gGourceSettings.commit_interval > 0.0f) {
+            if(commit_interval_count == 0) {
+                commit_interval_base = commit.timestamp;
+            }
+            commit.timestamp = commit_interval_base + (time_t)(commit_interval_count * gGourceSettings.commit_interval);
+            commit_interval_count++;
         }
 
         if(gGourceSettings.stop_timestamp != 0 && commit.timestamp > gGourceSettings.stop_timestamp) {

--- a/src/gource.h
+++ b/src/gource.h
@@ -178,6 +178,9 @@ class Gource : public SDLApp {
     int commitqueue_max_size;
     float starting_z;
 
+    int commit_interval_count;
+    time_t commit_interval_base;
+
     std::deque<RCommit> commitqueue;
     std::map<std::string, RUser*> users;
     std::map<std::string, RFile*> files;

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -74,6 +74,7 @@ void GourceSettings::help(bool extended_help) {
     printf("                                   for a number of seconds (default: 3)\n");
     printf("      --disable-auto-skip          Disable auto skip\n");
     printf("  -s, --seconds-per-day SECONDS    Speed in seconds per day (default: 10)\n");
+    printf("      --commit-interval SECONDS    Fixed number of seconds between commits\n");
     printf("      --realtime                   Realtime playback speed\n");
     printf("      --no-time-travel             Use the time of the last commit if the\n");
     printf("                                   time of a commit is in the past\n");
@@ -295,6 +296,7 @@ GourceSettings::GourceSettings() {
     arg_types["bloom-multiplier"]  = "float";
     arg_types["elasticity"]        = "float";
     arg_types["seconds-per-day"]   = "float";
+    arg_types["commit-interval"]   = "float";
     arg_types["auto-skip-seconds"] = "float";
     arg_types["stop-at-time"]      = "float";
     arg_types["max-user-speed"]    = "float";
@@ -408,6 +410,7 @@ void GourceSettings::setGourceDefaults() {
 
     auto_skip_seconds     = 3.0f;
     days_per_second       = 0.1f; // TODO: check this is right
+    commit_interval       = -1.0f;
     file_idle_time        = 0.0f;
     file_idle_time_at_end = 0.0f;
     time_scale            = 1.0f;
@@ -1206,6 +1209,20 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
 
         // convert seconds-per-day to days-per-second
         days_per_second = 1.0 / seconds_per_day;
+    }
+
+    if((entry = gource_settings->getEntry("commit-interval")) != 0) {
+
+        if(!entry->hasValue()) conffile.entryException(entry, "specify commit-interval (seconds)");
+
+        commit_interval = entry->getFloat();
+
+        if(commit_interval <= 0.0f) {
+            conffile.invalidValueException(entry);
+        }
+
+        // disable auto-skip in commit-interval mode
+        auto_skip_seconds = -1.0f;
     }
 
     if((entry = gource_settings->getEntry("auto-skip-seconds")) != 0) {

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -75,6 +75,7 @@ public:
 
     float auto_skip_seconds;
     float days_per_second;
+    float commit_interval;
     float file_idle_time;
     float file_idle_time_at_end;
     float loop_delay_seconds;


### PR DESCRIPTION
## Summary
- Adds `--commit-interval SECONDS` option that spaces commits at a fixed time interval regardless of real timestamps
- Commits remain chronologically ordered but each one appears exactly N seconds after the previous
- Auto-skip is automatically disabled when using this mode
- Useful for demos/presentations where clarity between commits matters more than historical time accuracy

Closes #357

## Usage
```
gource --commit-interval 4
```
Each commit will appear 4 seconds after the previous one, regardless of actual commit dates.

## Implementation
- Timestamps are remapped in `readLog()` as commits are read from the log: `new_timestamp = first_commit_time + (commit_index * interval)`
- The original chronological ordering is preserved
- `--auto-skip-seconds` is disabled since fixed intervals make it redundant

## Test plan
- [ ] Build and run with `--commit-interval 4` on a repository
- [ ] Verify commits appear at regular intervals
- [ ] Verify it works with `--stop-at-end`, `--loop`, and other timing options
- [ ] Verify `--seconds-per-day` still controls animation speed between commits
- [ ] Verify auto-skip is correctly disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)