### PR TITLE
Add single-slot caption mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 0.57:
+ * Added --single-slot-captions option for replacing overlapping captions.
  * Handle loading indexed colour images (sokripon).
 
 0.56:

--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ options:
     --caption-offset X
             Caption horizontal offset (0 to centre captions).
 
+    --single-slot-captions
+            Replace any visible caption with the next caption instead of
+            stacking overlapping captions.
+
     -o, --output-ppm-stream FILE
             Output a PPM image stream to a file ('-' for STDOUT).
 

--- a/data/gource.1
+++ b/data/gource.1
@@ -300,6 +300,9 @@ Caption duration.
 \fB\-\-caption-offset X
 Caption horizontal offset (0 to centre captions).
 .TP
+\fB\-\-single-slot-captions
+Replace any visible caption with the next caption instead of stacking overlapping captions.
+.TP
 \fB\-o, \-\-output\-ppm\-stream FILE\fR
 Output a PPM image stream to a file ('\-' for STDOUT).
 

--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1811,9 +1811,16 @@ void Gource::logic(float t, float dt) {
 
         if(caption->timestamp > currtime) break;
 
+        if(gGourceSettings.caption_single_slot) {
+            for(std::list<RCaption*>::iterator it = active_captions.begin(); it!=active_captions.end(); it++) {
+                delete (*it);
+            }
+            active_captions.clear();
+        }
+
         float y = caption_start_y;
 
-        while(1) {
+        while(!gGourceSettings.caption_single_slot) {
 
             bool found = false;
 

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -183,7 +183,8 @@ if(extended_help) {
     printf("  --caption-size SIZE         Caption font size\n");
     printf("  --caption-colour FFFFFF     Caption colour in hex\n");
     printf("  --caption-duration SECONDS  Caption duration (default: 10.0)\n");
-    printf("  --caption-offset X          Caption horizontal offset\n\n");
+    printf("  --caption-offset X          Caption horizontal offset\n");
+    printf("  --single-slot-captions      Replace visible captions instead of stacking\n\n");
 
     printf("  --hash-seed SEED         Change the seed of hash function.\n\n");
 
@@ -279,6 +280,7 @@ GourceSettings::GourceSettings() {
     arg_types["author-time"]             = "bool";
     arg_types["key"]                     = "bool";
     arg_types["ffp"]                     = "bool";
+    arg_types["single-slot-captions"]    = "bool";
 
     arg_types["disable-auto-rotate"] = "bool";
     arg_types["disable-auto-skip"]   = "bool";
@@ -481,6 +483,7 @@ void GourceSettings::setGourceDefaults() {
     caption_duration = 10.0f;
     caption_size     = 16;
     caption_offset   = 0;
+    caption_single_slot = false;
     caption_colour   = vec3(1.0f, 1.0f, 1.0f);
 
     filename_colour  = vec3(1.0f, 1.0f, 1.0f);
@@ -901,6 +904,10 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
         if(!entry->hasValue()) conffile.entryException(entry, "specify caption offset");
 
         caption_offset = entry->getInt();
+    }
+
+    if(gource_settings->getBool("single-slot-captions")) {
+        caption_single_slot = true;
     }
 
     if((entry = gource_settings->getEntry("caption-colour")) != 0) {

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -160,6 +160,7 @@ public:
     float caption_duration;
     int caption_size;
     int caption_offset;
+    bool caption_single_slot;
 
     vec3 filename_colour;
     float filename_time;


### PR DESCRIPTION
Implements `--single-slot-captions` for #344.

What changed:
- Adds a boolean caption setting and command-line flag.
- When enabled, a newly-triggered caption deletes any visible active captions before being displayed at the normal caption position.
- Updates README, man page, and ChangeLog.

Verification:
- `git diff --check` passed locally.
- I could not run the C++ test suite in this Windows environment because `make` and `g++` are not installed.

Bounty note:
- If this qualifies for the issue bounty, I am happy to coordinate payout details privately after acceptance and follow your preferred process.
