### PR TITLE
Add single-slot captions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ options:
     --caption-offset X
             Caption horizontal offset (0 to centre captions).
 
+    --single-slot-captions
+            Show at most one caption at a time.
+
     -o, --output-ppm-stream FILE
             Output a PPM image stream to a file ('-' for STDOUT).
 

--- a/data/gource.1
+++ b/data/gource.1
@@ -300,6 +300,9 @@ Caption duration.
 \fB\-\-caption-offset X
 Caption horizontal offset (0 to centre captions).
 .TP
+\fB\-\-single\-slot\-captions
+Show at most one caption at a time.
+.TP
 \fB\-o, \-\-output\-ppm\-stream FILE\fR
 Output a PPM image stream to a file ('\-' for STDOUT).
 

--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1811,9 +1811,16 @@ void Gource::logic(float t, float dt) {
 
         if(caption->timestamp > currtime) break;
 
+        if(gGourceSettings.single_slot_captions) {
+            for(RCaption* cap : active_captions) {
+                delete cap;
+            }
+            active_captions.clear();
+        }
+
         float y = caption_start_y;
 
-        while(1) {
+        while(!gGourceSettings.single_slot_captions) {
 
             bool found = false;
 

--- a/src/gource_settings.cpp
+++ b/src/gource_settings.cpp
@@ -183,7 +183,8 @@ if(extended_help) {
     printf("  --caption-size SIZE         Caption font size\n");
     printf("  --caption-colour FFFFFF     Caption colour in hex\n");
     printf("  --caption-duration SECONDS  Caption duration (default: 10.0)\n");
-    printf("  --caption-offset X          Caption horizontal offset\n\n");
+    printf("  --caption-offset X          Caption horizontal offset\n");
+    printf("  --single-slot-captions      Show at most one caption at a time\n\n");
 
     printf("  --hash-seed SEED         Change the seed of hash function.\n\n");
 
@@ -279,6 +280,7 @@ GourceSettings::GourceSettings() {
     arg_types["author-time"]             = "bool";
     arg_types["key"]                     = "bool";
     arg_types["ffp"]                     = "bool";
+    arg_types["single-slot-captions"]    = "bool";
 
     arg_types["disable-auto-rotate"] = "bool";
     arg_types["disable-auto-skip"]   = "bool";
@@ -482,6 +484,7 @@ void GourceSettings::setGourceDefaults() {
     caption_size     = 16;
     caption_offset   = 0;
     caption_colour   = vec3(1.0f, 1.0f, 1.0f);
+    single_slot_captions = false;
 
     filename_colour  = vec3(1.0f, 1.0f, 1.0f);
     filename_time = 4.0f;
@@ -919,6 +922,10 @@ void GourceSettings::importGourceSettings(ConfFile& conffile, ConfSection* gourc
         } else {
             conffile.invalidValueException(entry);
         }
+    }
+
+    if(gource_settings->getBool("single-slot-captions")) {
+        single_slot_captions = true;
     }
 
     if((entry = gource_settings->getEntry("filename-colour")) != 0) {

--- a/src/gource_settings.h
+++ b/src/gource_settings.h
@@ -160,6 +160,7 @@ public:
     float caption_duration;
     int caption_size;
     int caption_offset;
+    bool single_slot_captions;
 
     vec3 filename_colour;
     float filename_time;


### PR DESCRIPTION
## Summary
- add a `--single-slot-captions` boolean option
- when enabled, replace any currently active caption before showing the next one
- document the new option in the README and man page

Closes #344.

## Validation
- `git diff --check`
- Build not run locally: this Windows environment does not have Gource's native build toolchain available, and WSL has no installed distribution.

## Bounty note
This implements the single-slot caption behavior requested in #344. If accepted, I can coordinate the bounty payment method privately.