### PR TITLE
Fix early exit with stop-at-end when commits remain in queue

### DIFF
--- a/src/gource.cpp
+++ b/src/gource.cpp
@@ -1398,7 +1398,7 @@ void Gource::updateUsers(float t, float dt) {
         }
     }
 
-    if(users.empty() && stop_position_reached) {
+    if(users.empty() && stop_position_reached && commitqueue.empty()) {
         appFinished = true;
     }
 
@@ -1745,8 +1745,8 @@ void Gource::logic(float t, float dt) {
 
         RCommit commit = commitqueue.front();
 
-        //auto skip ahead, unless stop_position_reached
-        if(gGourceSettings.auto_skip_seconds>=0.0 && idle_time >= gGourceSettings.auto_skip_seconds && !stop_position_reached) {
+        //auto skip ahead, unless stop_position_reached (still allow skip while commits remain queued)
+        if(gGourceSettings.auto_skip_seconds>=0.0 && idle_time >= gGourceSettings.auto_skip_seconds && (!stop_position_reached || !commitqueue.empty())) {
             currtime = lasttime = commit.timestamp;
             idle_time = 0.0;
         }


### PR DESCRIPTION
## Summary

When rendering to video (`-o`), Gource can stop the simulation before the final commits are processed if there is a long idle gap in the repository history.

This changes two guards in `Gource::logic()` / `Gource::updateUsers()` so that `stop_at_end` still waits for `commitqueue` to drain, and auto-skip remains enabled while queued commits are waiting.

## Problem

`-o` (and `--stop-at-end`) enable `stop_at_end` unless `--dont-stop`, `--loop`, or reading from stdin (`-`) is used (`gource_shell.cpp`).

In `readLog()`, once the commit log reaches EOF (`commitlog->isFinished()`), `stop_position_reached` is set immediately — even though commits with later timestamps may already be sitting in `commitqueue` waiting for simulation time to catch up.

Two consequences:

1. **Auto-skip is disabled** once `stop_position_reached` is true (`logic()`, ~line 1749), so Gource no longer jumps across idle gaps while those queued commits are pending.
2. **Exit does not check the queue** — `updateUsers()` sets `appFinished` when `users.empty() && stop_position_reached` (~line 1401), without requiring `commitqueue.empty()`.

On a repo with a multi-day gap followed by a burst of commits (e.g. last activity on 24 June, next commit on 30 June), the visualization can exit around the gap while the final commits never appear. The on-screen clock reflects the last *processed* time, not the last commit in the log.

Reproduced with stock Gource 0.56 on a real git repo: `gource --start-date '2026-06-20' --stop-date '2026-07-01' -1280x720 -o - <repo>` — last frame showed ~26 June; the 30 June commits were never rendered.

## Fix

1. **Exit guard** — only finish when the queue is drained:
   ```cpp
   if(users.empty() && stop_position_reached && commitqueue.empty())
   ```

2. **Auto-skip guard** — keep skipping idle time while commits remain queued after EOF:
   ```cpp
   if(... && (!stop_position_reached || !commitqueue.empty()))
   ```

No changes to log parsing, timestamp handling, or CLI flags.

## Test plan

- [x] Repo with a multi-day commit gap and activity after the gap: render with `-o` and confirm the final commits and clock date are shown
- [x] Same repo without `-o` / `--stop-at-end` — behaviour unchanged
- [x] `--dont-stop` and `--loop` paths unchanged
- [x] Short history with no gaps — still exits cleanly at end
- [x] `--stop-date` / `--stop-position` stopping before EOF — still stops at the requested point

Verified locally on macOS (arm64) against a git repo with a ~5.7-day gap (24 Jun → 30 Jun): stock build stopped ~26 Jun; patched build reached 30 Jun and exited on its own.